### PR TITLE
Add os portability for getting current time in milliseconds

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -70,10 +70,28 @@ uint64_t shard_size(int hops)
     return (8  * (1024 * 1024)) * pow(2, hops);
 };
 
-double get_time_milliseconds() {
-    // TODO os platform portability
+uint64_t get_time_milliseconds() {
+#ifdef _WIN32
+
+    // Time between windows epoch and standard epoch
+    const int64_t time_to_epoch = 116444736000000000LL;
+
+    FILETIME ft;
+
+    GetSystemTimePreciseAsFileTime(&ft);
+
+    LARGE_INTEGER li;
+    li.LowPart = ft.dwLowDateTime;
+    li.HighPart = ft.dwHighDateTime;
+    li.QuadPart -= time_to_epoch;
+    li.QuadPart /= 10000;
+
+    uint64_t milliseconds = li.QuadPart;
+#else
     struct timeval t;
     gettimeofday(&t, NULL);
-    double milliseconds = t.tv_sec * 1000LL + t.tv_usec / 1000;
+    uint64_t milliseconds = t.tv_sec * 1000LL + t.tv_usec / 1000;
+#endif
+
     return milliseconds;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,7 +13,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <math.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/time.h>
+#endif
 
 #define OK 0
 #define ERROR 1
@@ -28,6 +33,6 @@ void random_buffer(uint8_t *buf, size_t len);
 
 uint64_t shard_size(int hops);
 
-double get_time_milliseconds();
+uint64_t get_time_milliseconds();
 
 #endif /* STORJ_UTILS_H */


### PR DESCRIPTION
Tested using cross compilation with `x86_64-w64-mingw32-w32-gcc` and latest `wine-devel` from https://wiki.winehq.org/Ubuntu