### PR TITLE
Replace shard pointers on download failure

### DIFF
--- a/src/storj.c
+++ b/src/storj.c
@@ -75,6 +75,10 @@ char *storj_strerror(int error_code)
             return "Bridge request authorization error";
         case STORJ_BRIDGE_TOKEN_ERROR:
             return "Bridge request token error";
+        case STORJ_BRIDGE_POINTER_ERROR:
+            return "Bridge request pointer error";
+        case STORJ_BRIDGE_REPOINTER_ERROR:
+            return "Bridge request replace pointer error";
         case STORJ_BRIDGE_TIMEOUT_ERROR:
             return "Bridge request timeout error";
         case STORJ_BRIDGE_INTERNAL_ERROR:
@@ -89,6 +93,8 @@ char *storj_strerror(int error_code)
             return "Unexpected JSON response";
         case STORJ_FARMER_REQUEST_ERROR:
             return "Farmer request error";
+        case STORJ_FARMER_EXHAUSTED_ERROR:
+            return "Farmer exhausted error";
         case STORJ_FARMER_TIMEOUT_ERROR:
             return "Farmer request timeout error";
         case STORJ_FARMER_AUTH_ERROR:

--- a/src/storj.h
+++ b/src/storj.h
@@ -177,6 +177,7 @@ typedef struct {
     FILE *destination;
     storj_progress_cb progress_cb;
     storj_finished_download_cb finished_cb;
+    bool finished;
     uint64_t shard_size;
     uint32_t total_shards;
     uint32_t completed_shards;

--- a/test/mockbridge.c
+++ b/test/mockbridge.c
@@ -96,25 +96,29 @@ int mock_bridge_server(void *cls,
                 status_code = MHD_HTTP_OK;
             }
         } else if (0 == strcmp(url, "/buckets/368be0816766b28fd5f43af5/files/998960317b6725a3f8080c2b")) {
-            if (check_auth(user, pass, &status_code, page)) {
+            // TODO check token auth
 
-                const char* skip = MHD_lookup_connection_value(connection,
-                                                               MHD_GET_ARGUMENT_KIND,
-                                                               "skip");
-                if (!skip || 0 == strcmp(skip, "0")) {
-                    page = get_response_string(responses, "getfilepointers-0");
-                    status_code = MHD_HTTP_OK;
-                } else if (0 == strcmp(skip, "6")) {
-                    page = get_response_string(responses, "getfilepointers-1");
-                    status_code = MHD_HTTP_OK;
-                } else if (0 == strcmp(skip, "12")) {
-                    page = get_response_string(responses, "getfilepointers-2");
-                    status_code = MHD_HTTP_OK;
-                } else {
-                    page = "[]";
-                    status_code = MHD_HTTP_OK;
-                }
+            const char* skip = MHD_lookup_connection_value(connection,
+                                                           MHD_GET_ARGUMENT_KIND,
+                                                           "skip");
+            if (!skip || 0 == strcmp(skip, "0")) {
+                page = get_response_string(responses, "getfilepointers-0");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "6")) {
+                page = get_response_string(responses, "getfilepointers-1");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "12")) {
+                page = get_response_string(responses, "getfilepointers-2");
+                status_code = MHD_HTTP_OK;
+            } else if (0 == strcmp(skip, "4")) {
+                // TODO check exclude and limit query
+                page = get_response_string(responses, "getfilepointers-r");
+                status_code = MHD_HTTP_OK;
+            } else {
+                page = "[]";
+                status_code = MHD_HTTP_OK;
             }
+
         } else if (0 == strcmp(url, "/frames")) {
             if (check_auth(user, pass, &status_code, page)) {
                 page = get_response_string(responses, "getframes");

--- a/test/mockbridge.json
+++ b/test/mockbridge.json
@@ -2293,5 +2293,22 @@
       "index": 13,
       "size": 16777216
     }
+  ],
+  "getfilepointers-r": [
+    {
+      "token": "2d9ae13d317209c1523b80716f186f887a4c7d3a",
+      "hash": "b3262bf52f0ce496a0f66f3a04006a275c03bc7e",
+      "farmer": {
+        "userAgent": "6.0.1",
+        "protocol": "1.0.0",
+        "address": "localhost",
+        "port": 8092,
+        "nodeID": "15a02aed7a92e593d03d6cd1f43c0ab504131296",
+        "lastSeen": 1480963977022
+      },
+      "operation": "PULL",
+      "index": 4,
+      "size": 16777216
+    }
   ]
 }

--- a/test/tests.c
+++ b/test/tests.c
@@ -163,7 +163,7 @@ void check_resolve_file(int status, FILE *fd)
     fclose(fd);
     if (status) {
         fail("storj_bridge_resolve_file");
-        printf("Download failed: %s", storj_strerror(status));
+        printf("Download failed: %s\n", storj_strerror(status));
     } else {
         pass("storj_bridge_resolve_file");
     }

--- a/test/tests.c
+++ b/test/tests.c
@@ -161,9 +161,12 @@ void check_resolve_file_progress(double progress)
 void check_resolve_file(int status, FILE *fd)
 {
     fclose(fd);
-    assert(status == 0);
-
-    pass("storj_bridge_resolve_file");
+    if (status) {
+        fail("storj_bridge_resolve_file");
+        printf("Download failed: %s", storj_strerror(status));
+    } else {
+        pass("storj_bridge_resolve_file");
+    }
 }
 
 void check_store_file_progress(double progress)


### PR DESCRIPTION
After a failure to download a shard from a farmer and sending an exchange report, this will replace the pointer with another farmer that has a mirror, so that the file can continue to be downloaded.