### PR TITLE
Load mock bridge responses at compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ TAGS
 *.swp
 libstorj.pc
 docs
+test/*.json.h

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,12 @@ AC_CONFIG_MACRO_DIR([build-aux/m4])
 AM_INIT_AUTOMAKE([foreign])
 LT_INIT
 
+AC_PATH_PROG(HEXDUMP,hexdump)
+
+if test x$HEXDUMP = x; then
+AC_MSG_ERROR(hexdump is required for tests)
+fi
+
 PKG_PROG_PKG_CONFIG
 if test -z "$PKG_CONFIG"; then
    AC_MSG_ERROR([pkg-config not found. pkg-config is required to check for some dependencies.])

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,18 @@
 noinst_PROGRAMS = tests
-tests_SOURCES = mockbridge.c mockfarmer.c tests.c storjtests.h $(top_builddir)/src/storj.h
+tests_SOURCES = mockbridge.c mockfarmer.c tests.c storjtests.h $(top_builddir)/src/storj.h mockbridge.json.h
 tests_LDADD = $(top_builddir)/src/libstorj.la
 tests_LDFLAGS = -Wall -g -static -lmicrohttpd
 TESTS = tests
+
+CLEANFILES = mockbridge.json.h
+
+mockbridge.c: mockbridge.json.h
+
+%.json.h: %.json
+	@$(MKDIR_P) $(@D)
+	@{ \
+	 echo "static const char $(*F)_json[] = {" && \
+	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
+	 echo "};"; \
+	} > "$@.new" && mv -f "$@.new" "$@"
+	@echo "Generated $@"

--- a/test/mockbridge.c
+++ b/test/mockbridge.c
@@ -35,7 +35,19 @@ int mock_bridge_server(void *cls,
 
     struct MHD_Response *response;
 
-    struct json_object *responses = json_tokener_parse(mockbridge_json);
+    json_tokener *tok = json_tokener_new();
+    json_object *responses = NULL;
+    int stringlen = 0;
+    enum json_tokener_error jerr;
+    do {
+        stringlen = strlen(mockbridge_json);
+        responses = json_tokener_parse_ex(tok, mockbridge_json, stringlen);
+    } while ((jerr = json_tokener_get_error(tok)) == json_tokener_continue);
+
+    if (jerr != json_tokener_success) {
+        fprintf(stderr, "Error: %s\n", json_tokener_error_desc(jerr));
+        exit(1);
+    }
 
     char *page = "Not Found";
     int status_code = MHD_HTTP_NOT_FOUND;

--- a/test/mockbridge.c
+++ b/test/mockbridge.c
@@ -11,37 +11,6 @@ char *get_response_string(json_object *obj, const char *key)
     }
 }
 
-struct json_object *get_response_json(char *path)
-{
-    FILE *f = fopen(path, "r");
-    if (f == NULL) {
-        printf("Error reading %s", path);
-        exit(1);
-    }
-
-    fseek(f, 0, SEEK_END);
-    long fsize = ftell(f);
-    fseek(f, 0, SEEK_SET);
-
-    char *json_string = malloc(fsize + 1);
-
-    size_t len = fread(json_string, fsize, 1, f);
-    if (len == 0) {
-        printf("Error reading %s", path);
-        exit(1);
-    }
-
-    fclose(f);
-
-    json_string[fsize] = 0;
-
-    struct json_object *j = json_tokener_parse(json_string);
-
-    free(json_string);
-
-    return j;
-}
-
 bool check_auth(char *user, char *pass, int *status_code, char *page)
 {
     if (user && 0 == strcmp(user, USER) && 0 == strcmp(pass, PASSHASH)) {
@@ -66,7 +35,7 @@ int mock_bridge_server(void *cls,
 
     struct MHD_Response *response;
 
-    json_object *responses = get_response_json("test/mockbridge.json");
+    struct json_object *responses = json_tokener_parse(mockbridge_json);
 
     char *page = "Not Found";
     int status_code = MHD_HTTP_NOT_FOUND;

--- a/test/storjtests.h
+++ b/test/storjtests.h
@@ -6,6 +6,8 @@
 #include "../src/utils.h"
 #include "../src/crypto.h"
 
+#include "mockbridge.json.h"
+
 #define KRED  "\x1B[31m"
 #define KGRN  "\x1B[32m"
 #define RESET "\x1B[0m"


### PR DESCRIPTION
- Dumps mockbridge.json into mockbridge.json.h during build
- Loads mockbridge.json.h so that reading from a file is not necessary,
  and dependent upon the location of the file