### PR TITLE
Prevent bzero/memset from being optimized away

### DIFF
--- a/src/downloader.c
+++ b/src/downloader.c
@@ -38,12 +38,12 @@ static void free_download_state(storj_download_state_t *state)
     }
 
     if (state->decrypt_key) {
-        bzero(state->decrypt_key, SHA256_DIGEST_SIZE);
+        memset(state->decrypt_key, 0, SHA256_DIGEST_SIZE);
         free(state->decrypt_key);
     }
 
     if (state->decrypt_ctr) {
-        bzero(state->decrypt_ctr, AES_BLOCK_SIZE);
+        memset(state->decrypt_ctr, 0, AES_BLOCK_SIZE);
         free(state->decrypt_ctr);
     }
 
@@ -618,10 +618,10 @@ static void free_request_shard_work(uv_handle_t *progress_handle)
     uv_work_t *work = progress_handle->data;
     shard_request_download_t *req = work->data;
 
-    bzero(req->decrypt_key, SHA256_DIGEST_SIZE);
+    memset(req->decrypt_key, 0, SHA256_DIGEST_SIZE);
     free(req->decrypt_key);
 
-    bzero(req->decrypt_ctr, AES_BLOCK_SIZE);
+    memset(req->decrypt_ctr, 0, AES_BLOCK_SIZE);
     free(req->decrypt_ctr);
 
     free(req);
@@ -1108,7 +1108,7 @@ int storj_bridge_resolve_file(storj_env_t *env,
         sha256_of_str(file_key, DETERMINISTIC_KEY_SIZE, decrypt_key);
         decrypt_key[SHA256_DIGEST_SIZE] = '\0';
 
-        bzero(file_key, DETERMINISTIC_KEY_SIZE + 1);
+        memset(file_key, 0, DETERMINISTIC_KEY_SIZE + 1);
         free(file_key);
 
         state->decrypt_key = decrypt_key;

--- a/src/downloader.c
+++ b/src/downloader.c
@@ -38,12 +38,12 @@ static void free_download_state(storj_download_state_t *state)
     }
 
     if (state->decrypt_key) {
-        memset(state->decrypt_key, 0, SHA256_DIGEST_SIZE);
+        memset_zero(state->decrypt_key, SHA256_DIGEST_SIZE);
         free(state->decrypt_key);
     }
 
     if (state->decrypt_ctr) {
-        memset(state->decrypt_ctr, 0, AES_BLOCK_SIZE);
+        memset_zero(state->decrypt_ctr, AES_BLOCK_SIZE);
         free(state->decrypt_ctr);
     }
 
@@ -618,10 +618,10 @@ static void free_request_shard_work(uv_handle_t *progress_handle)
     uv_work_t *work = progress_handle->data;
     shard_request_download_t *req = work->data;
 
-    memset(req->decrypt_key, 0, SHA256_DIGEST_SIZE);
+    memset_zero(req->decrypt_key, SHA256_DIGEST_SIZE);
     free(req->decrypt_key);
 
-    memset(req->decrypt_ctr, 0, AES_BLOCK_SIZE);
+    memset_zero(req->decrypt_ctr, AES_BLOCK_SIZE);
     free(req->decrypt_ctr);
 
     free(req);
@@ -1108,7 +1108,7 @@ int storj_bridge_resolve_file(storj_env_t *env,
         sha256_of_str(file_key, DETERMINISTIC_KEY_SIZE, decrypt_key);
         decrypt_key[SHA256_DIGEST_SIZE] = '\0';
 
-        memset(file_key, 0, DETERMINISTIC_KEY_SIZE + 1);
+        memset_zero(file_key, DETERMINISTIC_KEY_SIZE + 1);
         free(file_key);
 
         state->decrypt_key = decrypt_key;

--- a/src/storj.c
+++ b/src/storj.c
@@ -143,7 +143,7 @@ int storj_destroy_env(storj_env_t *env)
     // zero out password before freeing
     unsigned int pass_len = strlen(env->bridge_options->pass);
     if (pass_len > 0) {
-        bzero(env->bridge_options->pass, pass_len);
+        memset(env->bridge_options->pass, 0, pass_len);
     }
     free(env->bridge_options->pass);
     free(env->bridge_options);
@@ -153,7 +153,7 @@ int storj_destroy_env(storj_env_t *env)
 
     // zero out file encryption mnemonic before freeing
     if (mnemonic_len > 0) {
-        bzero(env->encrypt_options->mnemonic, mnemonic_len);
+        memset(env->encrypt_options->mnemonic, 0, mnemonic_len);
     }
     free(env->encrypt_options->mnemonic);
     free(env->encrypt_options);

--- a/src/storj.c
+++ b/src/storj.c
@@ -1,5 +1,6 @@
 #include "storj.h"
 #include "http.h"
+#include "utils.h"
 
 static inline void noop() {};
 
@@ -143,7 +144,7 @@ int storj_destroy_env(storj_env_t *env)
     // zero out password before freeing
     unsigned int pass_len = strlen(env->bridge_options->pass);
     if (pass_len > 0) {
-        memset(env->bridge_options->pass, 0, pass_len);
+        memset_zero(env->bridge_options->pass, pass_len);
     }
     free(env->bridge_options->pass);
     free(env->bridge_options);
@@ -153,7 +154,7 @@ int storj_destroy_env(storj_env_t *env)
 
     // zero out file encryption mnemonic before freeing
     if (mnemonic_len > 0) {
-        memset(env->encrypt_options->mnemonic, 0, mnemonic_len);
+        memset_zero(env->encrypt_options->mnemonic, mnemonic_len);
     }
     free(env->encrypt_options->mnemonic);
     free(env->encrypt_options);

--- a/src/utils.c
+++ b/src/utils.c
@@ -95,3 +95,15 @@ uint64_t get_time_milliseconds() {
 
     return milliseconds;
 }
+
+void memset_zero(void *v, size_t n)
+{
+#ifdef _WIN32
+    SecureZeroMemory(v, n);
+#else
+    volatile unsigned char *p = v;
+    while (n--) {
+        *p++ = 0;
+    }
+#endif
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,4 +35,6 @@ uint64_t shard_size(int hops);
 
 uint64_t get_time_milliseconds();
 
+void memset_zero(void *v, size_t n);
+
 #endif /* STORJ_UTILS_H */


### PR DESCRIPTION
Documentation for bzero marks the method as deprecated