### PR TITLE
Cross compile to OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,6 @@ depends/downloads/*
 depends/sources/*
 depends/build/*
 depends/toolchain/*
+depends/MacOSX10.11.sdk.tar.gz
+depends/MacOSX10.11.sdk/
 !depends/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,5 @@ test/tests.exe
 depends/downloads/*
 depends/sources/*
 depends/build/*
+depends/toolchain/*
 !depends/Makefile

--- a/README.md
+++ b/README.md
@@ -137,23 +137,10 @@ The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](
 
 ```
 cd ./depends
-make HOST="x86_64-apple-darwin11"
+make HOST="x86_64-apple-darwin11" DARWIN_SDK_PATH="/path/to/MacOSX10.11.sdk"
 ```
 
 Configure command for libstorj-c:
 ```
 export PATH="$(pwd)/depends/toolchain/build/bin:${PATH}" && PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-apple-darwin11/lib/pkgconfig" CC=clang CXX=clang++ CFLAGS="-target x86_64-apple-darwin11 -isysroot $(pwd)/depends/MacOSX10.11.sdk -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(pwd)/depends/build/x86_64-apple-darwin11/include" LDFLAGS="-L$(pwd)/depends/toolchain/build/lib -L$(pwd)/depends/MacOSX10.11.sdk/usr/lib -L$(pwd)/depends/build/x86_64-apple-darwin11/lib -Wl,-syslibroot $(pwd)/depends/MacOSX10.11.sdk" ./configure --host="x86_64-apple-darwin11" --enable-static --disable-shared --prefix=$(pwd)/depends/build/x86_64-apple-darwin11
-```
-
-
-### Compiling Dependencies from OS X
-
-```
-cd ./depends
-make HOST="x86_64-apple-darwin11"
-```
-
-Configure command for libstorj-c:
-```
-CC=clang CXX=clang++ CFLAGS="-target x86_64-apple-darwin11 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.12.sdk" PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-apple-darwin11/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/x86_64-apple-darwin11/include -L$(pwd)/depends/build/x86_64-apple-darwin11/lib" ./configure --host=x86_64-apple-darwin11 --enable-static --disable-shared --prefix=$(pwd)/depends/build/x86_64-apple-darwin11
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ PKG_CONFIG_LIBDIR="$(pwd)/depends/build/i686-pc-linux-gnu/lib/pkgconfig" CFLAGS=
 
 **Mac OSX**
 
-The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) *(requires a developer account)*.
+The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) *(requires a developer account)*. You may also need to symlink `/System/Library/Frameworks/Security.framework` to `/path/to/MacOSX10.11.sdk/System/Library/Frameworks/Security.framework` to have `darwinssl` be enabled during the build.
 
 ```
 cd ./depends

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ Configure command for libstorj-c:
 PKG_CONFIG_LIBDIR="$(pwd)/depends/build/i686-pc-linux-gnu/lib/pkgconfig" CFLAGS="-I$(pwd)/depends/build/i686-pc-linux-gnu/include -L$(pwd)/depends/build/i686-pc-linux-gnu/lib -static -m32" LDFLAGS="-m32" ./configure --host=i686-pc-linux-gnu --enable-static --disable-shared --prefix=$(pwd)/depends/build/i686-pc-linux-gnu
 ```
 
+**Mac OSX**
+
+The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) *(requires a developer account)*.
+
+```
+cd ./depends
+make HOST="x86_64-apple-darwin11"
+```
+
+Configure command for libstorj-c:
+```
+export PATH="$(pwd)/depends/toolchain/build/bin:${PATH}" && PKG_CONFIG_LIBDIR="$(pwd)/depends/build/x86_64-apple-darwin11/lib/pkgconfig" CC=clang CXX=clang++ CFLAGS="-target x86_64-apple-darwin11 -isysroot $(pwd)/depends/MacOSX10.11.sdk -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(pwd)/depends/build/x86_64-apple-darwin11/include" LDFLAGS="-L$(pwd)/depends/toolchain/build/lib -L$(pwd)/depends/MacOSX10.11.sdk/usr/lib -L$(pwd)/depends/build/x86_64-apple-darwin11/lib -Wl,-syslibroot $(pwd)/depends/MacOSX10.11.sdk" ./configure --host="x86_64-apple-darwin11" --enable-static --disable-shared --prefix=$(pwd)/depends/build/x86_64-apple-darwin11
+```
+
+
 ### Compiling Dependencies from OS X
 
 ```

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ PKG_CONFIG_LIBDIR="$(pwd)/depends/build/i686-pc-linux-gnu/lib/pkgconfig" CFLAGS=
 
 **Mac OSX**
 
-The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) *(requires a developer account)*. You may also need to symlink `/System/Library/Frameworks/Security.framework` to `/path/to/MacOSX10.11.sdk/System/Library/Frameworks/Security.framework` to have `darwinssl` be enabled during the build.
+The Apple SDK `MacOSX10.11.sdk` is needed and is available in [Xcode_7.3.1.dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg) *(requires a developer account)*. You can extract the sdk using `./depends/extract-osx-sdk.sh`:
+
+```
+apt-get install p7zip-full sleuthkit
+./depends/extract-osx-sdk.sh
+rm -rf 5.hfs MacOSX10.11.sdk
+```
+
+You may also need to symlink `/System/Library/Frameworks/Security.framework` to `/path/to/MacOSX10.11.sdk/System/Library/Frameworks/Security.framework` to have `darwinssl` be enabled during the build.
 
 ```
 cd ./depends

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -34,14 +34,15 @@ host_os=$(full_host_os)
 endif
 
 # mac build
-DARWIN_SDK_PATH ?= "/Library/Developer/CommandLineTools/SDKs/MacOSX10.12.sdk"
-DARWIN_CFLAGS = "-target $(HOST) -isysroot $(DARWIN_SDK_PATH)"
+DARWIN_SDK_PATH ?= "/home/bgf/storj/libstorj-c/depends/MacOSX10.11.sdk"
+DARWIN_CFLAGS = "-target $(HOST) -isysroot $(DARWIN_SDK_PATH) -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(PREFIX_DIR)include"
+DARWIN_LDFLAGS="-L/home/bgf/vendor/clang+llvm/lib -L$(DARWIN_SDK_PATH)/usr/lib -L$(PREFIX_DIR)lib -Wl,-syslibroot $(DARWIN_SDK_PATH)"
 
 build_SHA256SUM = $(if "$(build_os)" == "darwin",shasum -a 256,sha256sum -c)
 
 build_env=
 ifeq ($(host_os), darwin)
-build_env=CC=clang CXX=clang++ CFLAGS=$(DARWIN_CFLAGS)
+build_env=PATH="/home/bgf/vendor/clang+llvm/bin:${PATH}" CC=clang CXX=clang++ CFLAGS=$(DARWIN_CFLAGS) LDFLAGS=$(DARWIN_LDFLAGS)
 endif
 ifeq ($(HOST), i686-pc-linux-gnu)
 build_env=CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32
@@ -87,6 +88,7 @@ define build_source
 	echo "host: $(HOST)" && \
 	echo "prefix: $(PREFIX_DIR)" && \
 	echo "====================================\n\n" && \
+	export PATH="/home/bgf/vendor/clang+llvm/bin:${PATH}" && \
 	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
 	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) --enable-static --disable-shared --prefix=$(PREFIX_DIR) || exit && \
 	make || exit && \

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -12,17 +12,6 @@ TOOLCHAIN_BUILD_DIR = "$(CURDIR)/toolchain/build/"
 TOOLCHAIN_SOURCE_DIR = "$(CURDIR)/toolchain/source/"
 
 canonical_host:=$(shell ./config.sub $(HOST))
-build:=$(shell ./config.sub $(BUILD))
-
-build_arch =$(firstword $(subst -, ,$(build)))
-build_vendor=$(word 2,$(subst -, ,$(build)))
-full_build_os:=$(subst $(build_arch)-$(build_vendor)-,,$(build))
-build_os:=$(findstring linux,$(full_build_os))
-build_os+=$(findstring darwin,$(full_build_os))
-build_os:=$(strip $(build_os))
-ifeq ($(build_os),)
-build_os=$(full_build_os)
-endif
 
 host_arch=$(firstword $(subst -, ,$(canonical_host)))
 host_vendor=$(word 2,$(subst -, ,$(canonical_host)))
@@ -40,7 +29,7 @@ DARWIN_SDK_PATH ?= "$(CURDIR)/MacOSX10.11.sdk"
 DARWIN_CFLAGS = "-target $(HOST) -isysroot $(DARWIN_SDK_PATH) -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(PREFIX_DIR)include"
 DARWIN_LDFLAGS="-L$(TOOLCHAIN_BUILD_DIR)lib -L$(DARWIN_SDK_PATH)/usr/lib -L$(PREFIX_DIR)lib -Wl,-syslibroot $(DARWIN_SDK_PATH)"
 
-build_SHA256SUM = $(if "$(build_os)" == "darwin",shasum -a 256,sha256sum -c)
+build_SHA256SUM = sha256sum -c
 
 build_env=
 ifeq ($(host_os), darwin)

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -8,6 +8,8 @@ HOST ?= $(BUILD)
 DOWNLOAD_DIR = "$(CURDIR)/downloads/"
 SOURCES_DIR = "$(CURDIR)/sources/$(HOST)/"
 PREFIX_DIR = "$(CURDIR)/build/$(HOST)/"
+TOOLCHAIN_BUILD_DIR = "$(CURDIR)/toolchain/build/"
+TOOLCHAIN_SOURCE_DIR = "$(CURDIR)/toolchain/source/"
 
 canonical_host:=$(shell ./config.sub $(HOST))
 build:=$(shell ./config.sub $(BUILD))
@@ -34,23 +36,25 @@ host_os=$(full_host_os)
 endif
 
 # mac build
-DARWIN_SDK_PATH ?= "/home/bgf/storj/libstorj-c/depends/MacOSX10.11.sdk"
+DARWIN_SDK_PATH ?= "$(CURDIR)/MacOSX10.11.sdk"
 DARWIN_CFLAGS = "-target $(HOST) -isysroot $(DARWIN_SDK_PATH) -mmacosx-version-min=10.8 -mlinker-version=253.9 -pipe -I$(PREFIX_DIR)include"
-DARWIN_LDFLAGS="-L/home/bgf/vendor/clang+llvm/lib -L$(DARWIN_SDK_PATH)/usr/lib -L$(PREFIX_DIR)lib -Wl,-syslibroot $(DARWIN_SDK_PATH)"
+DARWIN_LDFLAGS="-L$(TOOLCHAIN_BUILD_DIR)lib -L$(DARWIN_SDK_PATH)/usr/lib -L$(PREFIX_DIR)lib -Wl,-syslibroot $(DARWIN_SDK_PATH)"
 
 build_SHA256SUM = $(if "$(build_os)" == "darwin",shasum -a 256,sha256sum -c)
 
 build_env=
 ifeq ($(host_os), darwin)
-build_env=PATH="/home/bgf/vendor/clang+llvm/bin:${PATH}" CC=clang CXX=clang++ CFLAGS=$(DARWIN_CFLAGS) LDFLAGS=$(DARWIN_LDFLAGS)
+build_env=PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" CC=clang CXX=clang++ CFLAGS=$(DARWIN_CFLAGS) LDFLAGS=$(DARWIN_LDFLAGS)
 endif
 ifeq ($(HOST), i686-pc-linux-gnu)
 build_env=CFLAGS=-m32 CXXFLAGS=-m32 LDFLAGS=-m32
 endif
 
+toolchain_packages:=clang cctools
 packages:=gmp nettle gnutls libcurl json-c libuv libmicrohttpd
+all_packages = $(toolchain_packages) $(packages)
 
-$(foreach package,$(packages),$(eval include packages/$(package).mk))
+$(foreach package,$(all_packages),$(eval include packages/$(package).mk))
 
 define fetch_file
 	set -e && \
@@ -88,9 +92,38 @@ define build_source
 	echo "host: $(HOST)" && \
 	echo "prefix: $(PREFIX_DIR)" && \
 	echo "====================================\n\n" && \
-	export PATH="/home/bgf/vendor/clang+llvm/bin:${PATH}" && \
+	export PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" && \
 	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
 	$(build_env) $($(1)_config_env) ./configure --host="$(HOST)" $($(1)_config_opts) --enable-static --disable-shared --prefix=$(PREFIX_DIR) || exit && \
+	make || exit && \
+	make install || exit && \
+	cd "$(CURDIR)"
+endef
+
+define extract_toolchain_file
+	if test -d "$(TOOLCHAIN_SOURCE_DIR)$(1)"; then \
+	echo "Skipping extract: $(DOWNLOAD_DIR)$($(1)_file_name)"; \
+	else \
+	echo "Extracting: $(DOWNLOAD_DIR)$($(1)_file_name)"; \
+	mkdir -p "$(TOOLCHAIN_SOURCE_DIR)$(1)"; \
+	tar xf "$(DOWNLOAD_DIR)$($(1)_file_name)" -C "$(TOOLCHAIN_SOURCE_DIR)$(1)" --strip-components=1; \
+	fi
+endef
+
+define extract_toolchain_file_build
+	mkdir -p "$(TOOLCHAIN_BUILD_DIR)"; \
+	tar xfv "$(DOWNLOAD_DIR)$($(1)_file_name)" -C "$(TOOLCHAIN_BUILD_DIR)" --strip-components=1; \
+	rm -f $(TOOLCHAIN_BUILD_DIR)lib/libc++abi.so
+endef
+
+define build_darwin_toolchain
+	echo "Building darwin toolchain" && \
+	$(foreach package,$(toolchain_packages),$(call fetch_file,$(package));)
+	$(foreach package,clang,$(call extract_toolchain_file_build,$(package));)
+	$(foreach package,cctools,$(call extract_toolchain_file,$(package));)
+	cd "$(TOOLCHAIN_SOURCE_DIR)cctools/cctools" && \
+	if test -f "./autogen.sh"; then ./autogen.sh; fi && \
+	PATH="$(TOOLCHAIN_BUILD_DIR)bin:${PATH}" CC=clang CXX=clang++ ./configure --prefix="$(TOOLCHAIN_BUILD_DIR)" --target="x86_64-apple-darwin11" || exit && \
 	make || exit && \
 	make install || exit && \
 	cd "$(CURDIR)"
@@ -102,8 +135,11 @@ build-sources: extract-sources
 extract-sources: download-sources
 	@$(foreach package,$(packages),$(call extract_file,$(package));)
 
-download-sources:
+download-sources: build-toolchain
 	@$(foreach package,$(packages),$(call fetch_file,$(package));)
+
+build-toolchain:
+	@$(call build_darwin_toolchain,)
 
 clean:
 	$(RM) -rv $(DOWNLOAD_DIR)

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -105,6 +105,7 @@ define extract_toolchain_file_build
 	rm -f $(TOOLCHAIN_BUILD_DIR)lib/libc++abi.so
 endef
 
+ifeq ($(host_os), darwin)
 define build_darwin_toolchain
 	echo "Building darwin toolchain" && \
 	$(foreach package,$(toolchain_packages),$(call fetch_file,$(package));)
@@ -117,6 +118,11 @@ define build_darwin_toolchain
 	make install || exit && \
 	cd "$(CURDIR)"
 endef
+else
+define build_darwin_toolchain
+	echo "Skipping building darwin toolchain"
+endef
+endif
 
 build-sources: extract-sources
 	@$(foreach package,$(packages),$(call build_source,$(package));)

--- a/depends/extract-osx-sdk.sh
+++ b/depends/extract-osx-sdk.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+set -e
+
+INPUTFILE="Xcode_7.3.1.dmg"
+HFSFILENAME="5.hfs"
+SDKDIR="Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk"
+
+7z x "${INPUTFILE}" "${HFSFILENAME}"
+SDKNAME="$(basename "${SDKDIR}")"
+SDKDIRINODE=$(ifind -n "${SDKDIR}" "${HFSFILENAME}")
+fls "${HFSFILENAME}" -rpF ${SDKDIRINODE} |
+ while read type inode filename; do
+	inode="${inode::-1}"
+	if [ "${filename:0:14}" = "usr/share/man/" ]; then
+		continue
+	fi
+	filename="${SDKNAME}/$filename"
+	echo "Extracting $filename ..."
+	mkdir -p "$(dirname "$filename")"
+	if [ "$type" = "l/l" ]; then
+		ln -s "$(icat "${HFSFILENAME}" $inode)" "$filename"
+	else
+		icat "${HFSFILENAME}" $inode >"$filename"
+	fi
+done
+echo "Building ${SDKNAME}.tar.gz ..."
+MTIME="$(istat "${HFSFILENAME}" "${SDKDIRINODE}" | perl -nle 'm/Content Modified:\s+(.*?)\s\(/ && print $1')"
+find "${SDKNAME}" | sort | tar --no-recursion --mtime="${MTIME}" --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > "${SDKNAME}.tar.gz"
+echo 'All done!'

--- a/depends/packages/cctools.mk
+++ b/depends/packages/cctools.mk
@@ -1,0 +1,7 @@
+package=cctools
+$(package)_version=8e9c3f2506b51cf56725eaa60b6e90e240e249ca
+$(package)_download_path=https://github.com/tpoechtrager/cctools-port/archive/$($(package)_version).tar.gz
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=c413a0c29468518fa4980dd4fdf90f8ca13843d86df6041c22d38bd26358e512
+$(package)_config_env=
+$(package)_config_opts=

--- a/depends/packages/clang.mk
+++ b/depends/packages/clang.mk
@@ -1,0 +1,7 @@
+package=clang
+$(package)_version=3.9.1
+$(package)_download_path=http://releases.llvm.org/$($(package)_version)/clang+llvm-$($(package)_version)-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+$(package)_file_name=$(package)-$($(package)_version).tar.gz
+$(package)_sha256_hash=99d1ffd4be8fd3331b4d2478ada7ee6ed352729bfe4a1070450cdb9a3ce8ef9b
+$(package)_config_env=
+$(package)_config_opts=

--- a/depends/packages/gnutls.mk
+++ b/depends/packages/gnutls.mk
@@ -9,9 +9,8 @@ $(package)_config_env_default=NETTLE_CFLAGS="-static" GMP_CFLAGS="-static" PKG_C
 $(package)_config_opts_default=--with-included-libtasn1 --with-included-unistring --enable-local-libopts --disable-non-suiteb-curves --disable-doc --without-p11-kit
 
 # darwin specific settings
-$(package)_config_env_darwin=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib"
+$(package)_config_env_darwin=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig"
 $(package)_config_env_x86_64-apple-darwin11=$($(package)_config_env_darwin)
-$(package)_config_env_x86_64-apple-darwin16.4.0=$($(package)_config_env_darwin)
 
 # 32 bit linux settings
 $(package)_config_env_i686-pc-linux-gnu=NETTLE_CFLAGS="-static" GMP_CFLAGS="-static" PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -static -m32" CXXFLAGS="-m32" LDFLAGS="-m32"

--- a/depends/packages/libcurl.mk
+++ b/depends/packages/libcurl.mk
@@ -16,6 +16,10 @@ $(package)_config_env_i686-w64-mingw32=$($(package)_config_env_mingw32)
 # 32-bit linux specific settings
 $(package)_config_env_i686-pc-linux-gnu=LIBS="-lnettle -lhogweed -lgmp" LD_LIBRARY_PATH="$(PREFIX_DIR)lib" PKG_CONFIG_LIBDIR="$(PREFIX_DIR)lib/pkgconfig" CPPFLAGS="-I$(PREFIX_DIR)include -m32" LDFLAGS="-L$(PREFIX_DIR)lib -m32"
 
+# darwin specific settings
+$(package)_config_opts_darwin=--with-sysroot="$(DARWIN_SDK_PATH)" --disable-ftp --disable-file --disable-ldap --disable-ldaps --disable-rtsp --disable-dict --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher --enable-proxy --without-gnutls --with-darwinssl --without-ssl --disable-telnet
+$(package)_config_opts_x86_64-apple-darwin11=$($(package)_config_opts_darwin)
+
 # set settings based on host
 $(package)_config_env = $(if $($(package)_config_env_$(HOST)), $($(package)_config_env_$(HOST)), $($(package)_config_env_default))
 $(package)_config_opts = $(if $($(package)_config_opts_$(HOST)), $($(package)_config_opts_$(HOST)), $($(package)_config_opts_default))

--- a/depends/packages/nettle.mk
+++ b/depends/packages/nettle.mk
@@ -13,6 +13,10 @@ $(package)_config_env_mingw32=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CF
 $(package)_config_env_x86_64-w64-mingw32=$($(package)_config_env_mingw32)
 $(package)_config_env_i686-w64-mingw32=$($(package)_config_env_mingw32)
 
+# darwin specific settings
+$(package)_config_env_darwin=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig"
+$(package)_config_env_x86_64-apple-darwin11=$($(package)_config_env_darwin)
+
 # 32bit linux specific settings
 $(package)_config_env_i686-pc-linux-gnu=PKG_CONFIG_LIBDIR="$(PREFIX_DIR)/lib/pkgconfig" CFLAGS="-I$(PREFIX_DIR)include -L$(PREFIX_DIR)lib -m32" LDFLAGS="-m32"
 


### PR DESCRIPTION
Using clang+llvm toolchain from: http://releases.llvm.org/3.9.1/clang+llvm-3.9.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz

And then compiled cctools-port https://github.com/tpoechtrager/cctools-port at commit 8e9c3f2506b51cf56725eaa60b6e90e240e249ca using the above version of clang with this configure line:

PATH="/path/to/clang+llvm/bin:${PATH}" CC=clang CXX=clang++ ./configure --prefix="/path/to/clang+llvm" --target="x86_64-apple-darwin11"

Closes: https://github.com/Storj/libstorj-c/issues/165
Closes: https://github.com/Storj/libstorj-c/issues/162